### PR TITLE
Update Dockerfile

### DIFF
--- a/examples/tfc-agent-gke-simple/Dockerfile
+++ b/examples/tfc-agent-gke-simple/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 
-FROM hashicorp/tfc-agent
+#hadolint ignore=DL3007
+FROM hashicorp/tfc-agent:latest
 
 USER root
 
@@ -15,6 +16,4 @@ RUN mkdir -p /usr/local/gcloud \
 # Adding the package path to local
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
-# /home/tfc-agent/bin/tfc-agent is the entrypoint from the hashicorp image
-ENTRYPOINT ["/home/tfc-agent/bin/tfc-agent"]
-CMD ["-single"]
+USER tfc-agent


### PR DESCRIPTION
* Switch back to tfc-agent user.
* Remove entrypoint/cmd override, let single execution mode be controlled by the env var.
* Explicitly tag the source image (resolves Hadolint DL3006)