### PR TITLE
Fix variable defaults

### DIFF
--- a/modules/tfc-agent-gke/variables.tf
+++ b/modules/tfc-agent-gke/variables.tf
@@ -44,7 +44,7 @@ variable "ip_range_services_cider" {
 variable "network_name" {
   type        = string
   description = "Name for the VPC network"
-  default     = "tfc_agent_network"
+  default     = "tfc-agent-network"
 }
 
 variable "subnet_ip" {

--- a/modules/tfc-agent-mig-container-vm/main.tf
+++ b/modules/tfc-agent-mig-container-vm/main.tf
@@ -165,7 +165,7 @@ module "mig_template" {
   source_image         = reverse(split("/", module.gce_container.source_image))[0]
   metadata = merge(var.additional_metadata, {
     google-logging-enabled      = "true"
-    "gce_container-declaration" = module.gce_container.metadata_value
+    "gce-container-declaration" = module.gce_container.metadata_value
   })
   tags = [
     local.instance_name

--- a/modules/tfc-agent-mig-container-vm/variables.tf
+++ b/modules/tfc-agent-mig-container-vm/variables.tf
@@ -14,7 +14,7 @@ variable "region" {
 variable "network_name" {
   type        = string
   description = "Name for the VPC network"
-  default     = "tfc_agent_network"
+  default     = "tfc-agent-network"
 }
 
 variable "create_network" {

--- a/modules/tfc-agent-mig-vm/variables.tf
+++ b/modules/tfc-agent-mig-vm/variables.tf
@@ -14,7 +14,7 @@ variable "region" {
 variable "network_name" {
   type        = string
   description = "Name for the VPC network"
-  default     = "tfc_agent_network"
+  default     = "tfc-agent-network"
 }
 
 variable "create_network" {
@@ -133,7 +133,7 @@ variable "tfc_agent_auto_update" {
 variable "tfc_agent_name_prefix" {
   type        = string
   description = "This name may be used in the Terraform Cloud user interface to help easily identify the agent"
-  default     = "tfc_agent_mig-vm"
+  default     = "tfc-agent-mig-vm"
 }
 
 variable "tfc_agent_token" {


### PR DESCRIPTION
VPC and instance template names don't accept underscores

Resolves error in all three modules:
`Error: "name" ("tfc_agent_network") doesn't match regexp "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$`

And this error in the tfc-agent-mig-vm module:
`Error: Error creating instance template: googleapi: Error 400: Invalid value for field 'resource.name': 'tfc_agent_mig-vm-20230628185758630700000001'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)`